### PR TITLE
rpm: fix "configure: WARNING: invalid host type"

### DIFF
--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -6,9 +6,13 @@
 # Configure args
 %if 0%{?enable_fuse} == 1
 %define fuse_configure_args $(echo "--enable-sheepfs")
+%else
+%define fuse_configure_args %{nil}
 %endif
 %if 0%{?enable_zookeeper} == 1
 %define zookeeper_configure_args $(echo "--enable-zookeeper")
+%else
+%define zookeeper_configure_args %{nil}
 %endif
 
 Name: sheepdog


### PR DESCRIPTION
This commit fixes the above warning when `make rpm`. This happens if you `./configure` without `--enable-zookeeper` or `--enable-sheepfs` before `make rpm`. This is because `%{fuse_configure_args}` and/or `%{zookeeper_configure_args}` are not expanded at configure step during `make rpm`.

Now I set each of them to `%{nil}` as default if the corresponding `./configure` option was not given.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;